### PR TITLE
Add ability to customise icon

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Icons, IconButton, TooltipMessage, WithTooltip } from "@storybook/components";
+import { Icons, IconButton, TooltipMessage, WithTooltip, IconKey } from "@storybook/components";
 import { PARAM_KEY, PREFIX_PARAM_KEY, ICON_PARAM_KEY, INFO_LINK, TOOL_ID } from "./constants";
 import { useParameter } from '@storybook/api';
 
@@ -22,7 +22,7 @@ export const getLink = (prefix: string | undefined, link: string | undefined) =>
 export const Tool = () => {
   let param_link = useParameter(PARAM_KEY, null)
   let param_prefix = useParameter(PREFIX_PARAM_KEY, null)
-  let param_icon = useParameter(ICON_PARAM_KEY, "repository")
+  let param_icon = useParameter(ICON_PARAM_KEY, "repository") as IconKey;
   const link = getLink(param_prefix, param_link)
 
   return (

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Icons, IconButton, TooltipMessage, WithTooltip } from "@storybook/components";
-import { PARAM_KEY, PREFIX_PARAM_KEY, INFO_LINK, TOOL_ID } from "./constants";
+import { PARAM_KEY, PREFIX_PARAM_KEY, ICON_PARAM_KEY, INFO_LINK, TOOL_ID } from "./constants";
 import { useParameter } from '@storybook/api';
 
 const Tooltip = () => (
@@ -22,6 +22,7 @@ export const getLink = (prefix: string | undefined, link: string | undefined) =>
 export const Tool = () => {
   let param_link = useParameter(PARAM_KEY, null)
   let param_prefix = useParameter(PREFIX_PARAM_KEY, null)
+  let param_icon = useParameter(ICON_PARAM_KEY, "repository")
   const link = getLink(param_prefix, param_link)
 
   return (
@@ -36,7 +37,7 @@ export const Tool = () => {
         }
       }}
     >
-      <Icons icon="repository" />
+      <Icons icon={param_icon} />
     </IconButton>
     :
     <WithTooltip placement="top" trigger="click" tooltip={<Tooltip />}>
@@ -45,7 +46,7 @@ export const Tool = () => {
         title="View Source Repository"
         active={false}
       >
-        <Icons icon="repository" />
+        <Icons icon={param_icon} />
       </IconButton>
     </WithTooltip>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,4 +2,5 @@ export const ADDON_ID = "storybook/source-link";
 export const TOOL_ID = `${ADDON_ID}/tool`;
 export const PARAM_KEY = `sourceLink`;
 export const PREFIX_PARAM_KEY = `sourceLinkPrefix`;
+export const ICON_PARAM_KEY = `sourceLinkIcon`;
 export const INFO_LINK = `https://github.com/Sirrine-Jonathan/storybook-source-link/blob/main/README.md`


### PR DESCRIPTION
Thanks for the addon 👍 

I wanted to use it to simply link back to my GitHub repo so I've added the ability to customise the icon by adding a new param `sourceLinkIcon`.

<img width="1322" alt="Screenshot 2023-02-16 at 16 18 07" src="https://user-images.githubusercontent.com/539309/219425013-9732b1d1-cf36-4899-84a1-15c32be0b49f.png">
